### PR TITLE
DEVX-2312: Enable local development environment for Commerce to rewri…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ application:
 ```
 Replace `{{YOUR_EVENT_TYPE}}` with your event and `actions/generic/index.js` with path to your function
 
+### Development
+The plugin subscribes to events during development session (`aio app run`) and cleanup subscriptions on CTRL+C
+
 ## Security
 We recommend to declare all your actions as non-web actions. This way only Adobe IO Events will be able to deliver data to your action.
 

--- a/src/hooks/register_events.js
+++ b/src/hooks/register_events.js
@@ -161,7 +161,7 @@ const hook = async function (options) {
   }
 
   if (!['app:deploy', 'app:undeploy', 'app:run'].includes(options.Command.id)) {
-    aioLogger.debug('App builder extension plugin works only for app:deploy command. Skipping...')
+    aioLogger.debug('App builder extension plugin works only for app:deploy and app:run commands. Skipping...')
     return
   }
 

--- a/src/hooks/register_events.js
+++ b/src/hooks/register_events.js
@@ -23,8 +23,6 @@ const ora = require('ora')
 const inquirer = require('inquirer')
 const prompt = inquirer.createPromptModule({ output: process.stderr })
 const { createSequenceIfNotExists, createPackageIfNotExists } = require('../utils')
-const EventEmitter = require('events');
-
 
 const ENTP_INT_CERTS_FOLDER = 'entp-int-certs'
 const CONSOLE_API_KEYS = {


### PR DESCRIPTION
DEVX-2312: Enable local development environment for Commerce to rewrite in-process modules to AB applications

<!--- Provide a general summary of your changes in the Title above -->

## Description
Support for `aio app run` command. The plugin will create registrations during development session and cleanup on ctrl+C

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
