### PR TITLE
Moved link between action & registration to Adobe I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Replace `{{YOUR_EVENT_TYPE}}` with your event and `actions/generic/index.js` wit
 Supported OpenWhisk entities: actions and sequences.
 
 ### Development
-The plugin subscribes to events during development session (`aio app run`) and cleanup subscriptions on CTRL+C
+We recommend using a separate workspace for development purposes, so please create/choose an existing workspace for development. Switch to the development workspace using `aio app use` CLI command.
+
+The plugin subscribes to events during development session (`aio app run`) and cleanup subscriptions on CTRL+C.
+
+Do not forget to switch back to production workspace when you are ready to deploy the code to production.
 
 ## Security
 We recommend to declare all your actions as non-web actions. This way only Adobe IO Events will be able to deliver data to your action.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-cli-plugin-extension",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "dependencies": {
     "@adobe/aio-cli-lib-app-config": "^0.2.1",
     "@adobe/aio-cli-lib-console": "^3.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change allows to develop event-based applications by multiple people and simplifies moving the project between different orgs/workspaces. This is achieved by moving a list of applied registration from local files to the services.

<!--- Describe your changes in detail -->

## Related Issue
DEVX-2504

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
